### PR TITLE
Limit time range in second table Office-DownloadsfromGuestafterAddedtoTeams.kql

### DIFF
--- a/Office 365/Office-DownloadsfromGuestafterAddedtoTeams.kql
+++ b/Office 365/Office-DownloadsfromGuestafterAddedtoTeams.kql
@@ -13,6 +13,7 @@ OfficeActivity
 | join kind=inner
     (
     OfficeActivity
+    | where TimeGenerated > ago(starttime)
     | where Operation in (['operations'])
     )
     on UserId


### PR DESCRIPTION
Put a time limit in second table call, so it does not search all available OfficeActivity records.