### PR TITLE
Use ActivityDateTime when available in Identity-RiskEventfollowedbyMFAchanges.kql

### DIFF
--- a/Azure Active Directory/Identity-RiskEventfollowedbyMFAchanges.kql
+++ b/Azure Active Directory/Identity-RiskEventfollowedbyMFAchanges.kql
@@ -4,7 +4,7 @@ let timeframe = 4h;
 AADUserRiskEvents
 | where TimeGenerated > ago(1d)
 | where RiskDetail != "aiConfirmedSigninSafe"
-| project RiskTime=TimeGenerated, UserPrincipalName, RiskEventType, RiskLevel, Source
+| project RiskTime=iff(isnotempty(ActivityDateTime), ActivityDateTime, TimeGenerated), UserPrincipalName, RiskEventType, RiskLevel, Source
 | join kind=inner (
     AuditLogs
     | where TimeGenerated > ago(1d)


### PR DESCRIPTION
Not all detections are realtime, so the MFA change could happen before the risk detection TimeGenerated.

And sadly sometimes DetectionDateTime and ActivityDateTime columns are all empty, and then the only option left would be to join by CorrelationId in SigninLogs and AADNonInteractivateSignInLogs and take their minTimeGenerated...

If this query wants to be exhaustive there should be a join with aad signinlogs tables.