### PR TITLE
Question about passwordless phone sign-in credential in Audit-MFAChangesforPrivlegedUsers.kql

### DIFF
--- a/Azure Active Directory/Audit-MFAChangesforPrivlegedUsers.kql
+++ b/Azure Active Directory/Audit-MFAChangesforPrivlegedUsers.kql
@@ -14,7 +14,7 @@ let privusers=
 //Lookup MFA configuration events for those privileged users
 AuditLogs
 | where TimeGenerated > ago(1d)
-| where OperationName in~ ("Admin registered security info", "Admin updated security info", "Admin deleted security info", "User registered security info", "User changed default security info", "User deleted security info")
+| where OperationName in~ ("Admin registered security info", "Admin updated security info", "Admin deleted security info", "User registered security info", "User changed default security info", "User deleted security info") //"Add passwordless phone sign-in credential")
 | extend UserPrincipalName = tostring(TargetResources[0].userPrincipalName)
 | where UserPrincipalName in~ (privusers)
 | project TimeGenerated, OperationName, UserPrincipalName


### PR DESCRIPTION
Hello, I have found the event ```OperationName == "Add passwordless phone sign-in credential"```.

In my case I was not able to associate this event the other events that appear in this query, like for example ```User registered security info```.

Additionally I only found a ```Update user``` event where the property ```SearchableDeviceKey``` is modified.

But, for the specific account of this event, the portal "Authentication methods" > "User registration details" shows "Microsoft Passwordless phone sign-in" as "Methods Registered".

![image](https://user-images.githubusercontent.com/2527990/223717044-2c87b96e-d1eb-4d00-aa24-c35e0982f4ed.png)
![image](https://user-images.githubusercontent.com/2527990/223717017-dd2b4410-ad07-4491-b353-869df8b2841d.png)

Please, I wanted to know if you observe the event ```Add passwordless phone sign-in credential``` to go associated with another event like "... security info", or if, on the contrary, the event ```OperationName == "Add passwordless phone sign-in credential"``` should be added to a query like this one, to check MFA changes.