### PR TITLE
Interchange difference times in Identity-SSPRfollowedbyRiskySignin.kql

### DIFF
--- a/Azure Active Directory/Identity-SSPRfollowedbyRiskySignin.kql
+++ b/Azure Active Directory/Identity-SSPRfollowedbyRiskySignin.kql
@@ -30,7 +30,7 @@ SigninLogs
         UserAgent
     )
     on UserPrincipalName
-| extend ['Time Between Events']=datetime_diff('minute', PasswordResetTime, RiskTime)
+| extend ['Time Between Events']=datetime_diff('minute', RiskTime, PasswordResetTime)
 | project-reorder
     PasswordResetTime,
     RiskTime,


### PR DESCRIPTION
I believe the current version is looking for SSPR events that happen until 2 hours after the risk event, instead of what is stated in the first line comment (risk event until 2 hours after the SSPR event).