### PR TITLE
Update OfficeActivity-DetectFullMailboxAccess.kql

### DIFF
--- a/Office 365/OfficeActivity-DetectFullMailboxAccess.kql
+++ b/Office 365/OfficeActivity-DetectFullMailboxAccess.kql
@@ -15,5 +15,5 @@ OfficeActivity
     ['Target Mailbox DisplayName']=OfficeObjectId,
     ['User Granted Access']=UserGivenAccess,
     ['Access Type']=AccessRights
-| where Actor != "NT AUTHORITY\\SYSTEM (Microsoft.Exchange.Servicehost)"
+| where tolower(Actor) != "nt authority\\system (microsoft.exchange.servicehost)"
 | sort by TimeGenerated desc 


### PR DESCRIPTION
Original 'where' clause was case sensitive and was still returning results for actor "NT AUTHORITY\SYSTEM (Microsoft.Exchange.ServiceHost)" (note the uppercase H in ServiceHost). 

Modified the query to use tolower(Actor) as a performant way to make the query case-insensitive.