### PR TITLE
Update Identity-DetectingFirstTimeAccesstoAzureManagement.kql

### DIFF
--- a/Azure Active Directory/Identity-DetectingFirstTimeAccesstoAzureManagement.kql
+++ b/Azure Active Directory/Identity-DetectingFirstTimeAccesstoAzureManagement.kql
@@ -18,4 +18,9 @@ SigninLogs
     )
     on UserPrincipalName, AppDisplayName
 | where ResultType == 0
-| project TimeGenerated, UserPrincipalName, ResultType, AppDisplayName, IPAddress, Location, UserAgent
+// Enrich Results with Identity Information
+| join kind=inner (IdentityInfo
+    | where TimeGenerated > timeframe
+    | summarize arg_max(TimeGenerated, *) by AccountUPN
+    | project AccountUPN, Department, AccountCreationTime) on $left.UserPrincipalName == $right.AccountUPN
+| project TimeGenerated, UserPrincipalName, ResultType, AppDisplayName, IPAddress, Location, UserAgent, Department, AccountCreationTime


### PR DESCRIPTION
Added extra context to the query by providing the Department and AccountCreationTime which can help to investigate incidents/hunts easily. Those two columns are needed to see if it is expected for such a department and/or if the user is recently added, and thus has never accessed a management portal before. 